### PR TITLE
SPROD-9310 install tmux cssh

### DIFF
--- a/sp.config.yml
+++ b/sp.config.yml
@@ -9,9 +9,10 @@ post_provision_tasks:
   - tasks/post-provision.yml
 
 sp_git_repos_local_directory: ~/envs
+
 sp_git_repos:
   - ansible
-  - cdef
+  - cdefx
   - paywall
   - publisher-feeds
   - single-api
@@ -20,6 +21,11 @@ sp_git_repos:
   - spdj
   - spfb
   - spv2
+
+pub_git_repos:
+  - peikk0/tmux-cssh
+
+pub_git_repos_local_directory: ~/install
 
 mas_installed_sp_apps: []
 

--- a/sp.config.yml
+++ b/sp.config.yml
@@ -12,7 +12,7 @@ sp_git_repos_local_directory: ~/envs
 
 sp_git_repos:
   - ansible
-  - cdefx
+  - cdef
   - paywall
   - publisher-feeds
   - single-api

--- a/tasks/post-provision.yml
+++ b/tasks/post-provision.yml
@@ -82,7 +82,7 @@
   tags: ['git','post-provision']
 
 - name: Copy tmux-cssh binary
-  command: /bin/cp {{ pub_git_repos_local_directory }}/tmux-cssh/tmux-cssh /usr/local/bin
+  command: /bin/cp {{ pub_git_repos_local_directory }}/peikk0/tmux-cssh/tmux-cssh /usr/local/bin
   become: no
   args:
     creates: /usr/local/bin/tmux-cssh

--- a/tasks/post-provision.yml
+++ b/tasks/post-provision.yml
@@ -82,8 +82,8 @@
 - name: Copy tmux-cssh binary
   command: /bin/cp {{ pub_git_repos_local_directory }}/tmux-cssh/tmux-cssh /usr/bin
   become: yes
-    args:
-      creates: /usr/bin/tmux-cssh
+  args:
+    creates: /usr/bin/tmux-cssh
 
 - name: Create pyenv virtualenv for ansible
   shell: pyenv virtualenv "{{ default_python_version }}" ansible

--- a/tasks/post-provision.yml
+++ b/tasks/post-provision.yml
@@ -86,7 +86,7 @@
   become: yes
   args:
     creates: /usr/bin/tmux-cssh
-  tags: ['git','post-provision']
+  tags: ['post-provision']
 
 - name: Create pyenv virtualenv for ansible
   shell: pyenv virtualenv "{{ default_python_version }}" ansible

--- a/tasks/post-provision.yml
+++ b/tasks/post-provision.yml
@@ -67,6 +67,7 @@
     bare: yes
   become: no
   with_items: "{{ pub_git_repos }}"
+  tags: ['git','post-provision']
 
 - name: Ensure other repos are available locally
   git:
@@ -78,12 +79,14 @@
     bare: no
   become: no
   with_items: "{{ pub_git_repos }}"
+  tags: ['git','post-provision']
 
 - name: Copy tmux-cssh binary
   command: /bin/cp {{ pub_git_repos_local_directory }}/tmux-cssh/tmux-cssh /usr/bin
   become: yes
   args:
     creates: /usr/bin/tmux-cssh
+  tags: ['git','post-provision']
 
 - name: Create pyenv virtualenv for ansible
   shell: pyenv virtualenv "{{ default_python_version }}" ansible

--- a/tasks/post-provision.yml
+++ b/tasks/post-provision.yml
@@ -58,6 +58,33 @@
   with_items: "{{ sp_git_repos }}"
   tags: ['git','post-provision']
 
+- name: Clone other repos
+  git:
+    repo: "gh:{{ item }}"
+    dest: "{{ pub_git_repos_local_directory }}/.{{ item }}"
+    version: master
+    recursive: yes
+    bare: yes
+  become: no
+  with_items: "{{ pub_git_repos }}"
+
+- name: Ensure other repos are available locally
+  git:
+    repo: "gh:{{ item }}"
+    dest: "{{ pub_git_repos_local_directory }}/{{ item }}"
+    version: master
+    recursive: yes
+    reference: "{{ pub_git_repos_local_directory }}/.{{ item }}"
+    bare: no
+  become: no
+  with_items: "{{ pub_git_repos }}"
+
+- name: Copy tmux-cssh binary
+  command: /bin/cp {{ pub_git_repos_local_directory }}/tmux-cssh/tmux-cssh /usr/bin
+  become: yes
+    args:
+       creates: /usr/bin/tmux-cssh
+
 - name: Create pyenv virtualenv for ansible
   shell: pyenv virtualenv "{{ default_python_version }}" ansible
   ignore_errors: yes

--- a/tasks/post-provision.yml
+++ b/tasks/post-provision.yml
@@ -82,10 +82,10 @@
   tags: ['git','post-provision']
 
 - name: Copy tmux-cssh binary
-  command: /bin/cp {{ pub_git_repos_local_directory }}/tmux-cssh/tmux-cssh /usr/bin
-  become: yes
+  command: /bin/cp {{ pub_git_repos_local_directory }}/tmux-cssh/tmux-cssh /usr/local/bin
+  become: no
   args:
-    creates: /usr/bin/tmux-cssh
+    creates: /usr/local/bin/tmux-cssh
   tags: ['post-provision']
 
 - name: Create pyenv virtualenv for ansible

--- a/tasks/post-provision.yml
+++ b/tasks/post-provision.yml
@@ -83,7 +83,7 @@
   command: /bin/cp {{ pub_git_repos_local_directory }}/tmux-cssh/tmux-cssh /usr/bin
   become: yes
     args:
-       creates: /usr/bin/tmux-cssh
+      creates: /usr/bin/tmux-cssh
 
 - name: Create pyenv virtualenv for ansible
   shell: pyenv virtualenv "{{ default_python_version }}" ansible


### PR DESCRIPTION
Since homebrew stopped hosting tmux-cssh, adding tasks to clone the git repo and copy binary to system path. More public github repos can be cloned into ~/install just by adding to pub_git_repos